### PR TITLE
Add a basic App Header

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,21 @@
 import React from 'react';
-import './App.css';
+import { Route, BrowserRouter, Switch } from 'react-router-dom';
 import InstrumentList from './containers/InstrumentList/InstrumentList';
 import InstrumentDetails from './containers/InstrumentDetails/InstrumentDetails';
-import { Route, BrowserRouter, Switch } from 'react-router-dom';
+import Layout from './hoc/Layout/Layout';
+import './App.css';
 
 const App = () => {
   
   return (
     <BrowserRouter>
       <div className="App">
-        <Switch>
-          <Route path='/gearitem' component={InstrumentDetails}/>
-          <Route path='/' component={InstrumentList}/>
-        </Switch>
+        <Layout>
+          <Switch>
+            <Route path='/gearitem' component={InstrumentDetails}/>
+            <Route path='/' component={InstrumentList}/>
+          </Switch>
+        </Layout>
       </div>
     </BrowserRouter>
   );

--- a/src/components/Navigation/Toolbar/Toolbar.css
+++ b/src/components/Navigation/Toolbar/Toolbar.css
@@ -1,0 +1,17 @@
+.Toolbar {
+  font-weight: bold;
+  font-size: 1.2em;
+  height: 50px;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #131212;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 10px;
+  box-sizing: border-box;
+  z-index: 90;
+  /* border-bottom: 2px solid #444444; */
+}

--- a/src/components/Navigation/Toolbar/Toolbar.js
+++ b/src/components/Navigation/Toolbar/Toolbar.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import './Toolbar.css';
+
+const Toolbar = () => (
+  <header className='Toolbar'>
+    GEAR PAGE
+  </header>
+)
+
+export default Toolbar;

--- a/src/hoc/Layout/Layout.css
+++ b/src/hoc/Layout/Layout.css
@@ -1,0 +1,3 @@
+.Content {
+  margin-top: 70px;
+}

--- a/src/hoc/Layout/Layout.js
+++ b/src/hoc/Layout/Layout.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Toolbar from '../../components/Navigation/Toolbar/Toolbar';
+import './Layout.css';
+
+const Layout = (props) => (
+  <React.Fragment>
+    <Toolbar />
+    <main className='Content'>
+      {props.children}
+    </main>
+  </React.Fragment>
+)
+
+export default Layout;


### PR DESCRIPTION
This MR adds a basic app header. Included in the MR is also a Layer hoc-component that adds the header to all app routes.

Resolves #17 