### PR TITLE
Put test case cleanup in after hooks

### DIFF
--- a/e2e/specs/gearDetails.test.js
+++ b/e2e/specs/gearDetails.test.js
@@ -1,12 +1,10 @@
 const { addGearItem, deleteGearItem } = require('../utils/firebaseAPI');
 const { bass, guitar } = require('../assets/testdata');
-
 let id;
 
 beforeEach(async () => {
   id = await addGearItem(bass);
   await page.goto(`${process.env.REACT_APP_FRONTEND}gearitem?id=${id}`, {waitUntil: 'networkidle'});
-  await page.waitForLoadState('networkidle');
 });
 
 test('Delete instrument', async () => {
@@ -15,14 +13,19 @@ test('Delete instrument', async () => {
   await expect(page).not.toHaveSelector(`#${id}`, {timeout: 1000})
 });
 
-test('Edit instrument', async () => {
-  await page.click('[data-test-id="editInstrument"]');
-  await page.selectOption('[data-test-id="formGearType"]', guitar.type);
-  await page.fill('[data-test-id="formGearName"]', guitar.name);
-  await page.fill('[data-test-id="formGearDescription"]', guitar.description);
-  await page.click('[data-test-id="submitGearFormButton"]');
-  await page.waitForSelector(`.${guitar.type}`)
-  await expect(page).toEqualText('[data-test-id="gearDetailsName"]', guitar.name)
-  await expect(page).toEqualText('[data-test-id="gearDetailsDescription"]', guitar.description)
-  await deleteGearItem(id);
-});
+describe('', () => {
+  test('Edit instrument', async () => {
+    await page.click('[data-test-id="editInstrument"]');
+    await page.selectOption('[data-test-id="formGearType"]', guitar.type);
+    await page.fill('[data-test-id="formGearName"]', guitar.name);
+    await page.fill('[data-test-id="formGearDescription"]', guitar.description);
+    await page.click('[data-test-id="submitGearFormButton"]');
+    await page.waitForSelector(`.${guitar.type}`)
+    await expect(page).toEqualText('[data-test-id="gearDetailsName"]', guitar.name)
+    await expect(page).toEqualText('[data-test-id="gearDetailsDescription"]', guitar.description)
+  });
+
+  afterEach(async () => {
+    await deleteGearItem(id);
+  });
+})

--- a/e2e/specs/gearList.test.js
+++ b/e2e/specs/gearList.test.js
@@ -1,13 +1,12 @@
 const { deleteGearItem } = require('../utils/firebaseAPI');
-const { bass } = require('../assets/testdata')
+const { bass } = require('../assets/testdata');
+const name = new Date().toLocaleString();
 
 beforeEach(async () => {
   await page.goto(process.env.REACT_APP_FRONTEND, {waitUntil: 'networkidle'});
-})
+});
 
 test('Add new instrument', async () => {
-  const name = new Date().toLocaleString();
-
   await page.click('[data-test-id="addNewInstrumentButton"]');
   await page.selectOption('[data-test-id="formGearType"]', bass.type);
   await page.fill('[data-test-id="formGearName"]', name);
@@ -15,6 +14,9 @@ test('Add new instrument', async () => {
   await page.click('[data-test-id="submitGearFormButton"]');
   await page.waitForLoadState('networkidle');
   await expect(page).toHaveText(`[name="${name}"]`, name);
+});
+
+afterEach(async () => {
   const id = await page.getAttribute(`[name="${name}"]`, 'id');
   await deleteGearItem(id);
 });


### PR DESCRIPTION
More robust cleanup when the commands are located in an after hook, allowing cleanup even if the test fails