### PR TITLE
e2e: Add missing env variable to the post-deploy tests ci job

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -41,6 +41,7 @@ jobs:
       FIREBASE_SC_CLIENT_EMAIL: ${{ secrets.FIREBASE_SC_CLIENT_EMAIL }}
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      REACT_APP_FIREBASE_AUTHDOMAIN: ${{ secrets.REACT_APP_FIREBASE_AUTHDOMAIN }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Yet another miss in the CI setup for the post-deploy e2e tests on browserstack. This time it was a missing env variable to set the baseURL. It's added now.