### PR TITLE
Aria label to UI

### DIFF
--- a/e2e/specs/gearDetails.test.js
+++ b/e2e/specs/gearDetails.test.js
@@ -24,22 +24,22 @@ test.describe('Gear details page', () => {
   });
 
   test('Edit instrument', async ({ page }) => {
-    await page.getByTestId('editInstrument').click();
-    await page.getByTestId('formGearType').selectOption('guitar');
-    await page.getByTestId('formGearName').fill('updated name');
-    await page.getByTestId('formGearDescription').fill('updated description');
-    await page.getByTestId('submitGearFormButton').click();
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByLabel('Type').selectOption('guitar');
+    await page.getByRole('textbox', { name: 'Name' }).fill('updated name');
+    await page.getByRole('textbox', { name: 'Description' }).fill('updated description');
+    await page.getByRole('button', { name: 'Update' }).click();
 
-    await expect(page.getByTestId('gearDetailsName')).toHaveText('updated name');
-    await expect(page.getByTestId('gearDetailsDescription')).toHaveText('updated description');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('updated name');
+    await expect(page.getByText('updated description')).toBeVisible();
   });
 
   test('Price is shown first when added to instrument', async ({ page }) => {
     await expect(page.getByTestId('price')).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Edit' }).click();
-    await page.getByTestId('formGearPrice').fill('123456');
+    await page.getByLabel('Price').fill('123456');
     await page.getByRole('button', { name: 'Update' }).click();
-    await expect(page.getByTestId('price')).toBeVisible();
+    await expect(page.getByText('Price: 123456 kr')).toBeVisible();
   });
 });

--- a/e2e/specs/gearList.test.js
+++ b/e2e/specs/gearList.test.js
@@ -15,10 +15,10 @@ test.describe('Gear list', () => {
 
   test('Add new instrument', async ({ page }) => {
     await page.getByTestId('addNewInstrumentButton').click();
-    await page.getByTestId('formGearType').selectOption('bass');
-    await page.getByTestId('formGearName').fill(name);
-    await page.getByTestId('formGearDescription').fill('Gear description');
-    await page.getByTestId('submitGearFormButton').click();
+    await page.getByLabel('Type').selectOption('bass');
+    await page.getByRole('textbox', { name: 'Name' }).fill(name);
+    await page.getByRole('textbox', { name: 'Description' }).fill('Gear description');
+    await page.getByRole('button', { name: 'Add' }).click();
 
     await expect(page.getByRole('row', { name })).toBeVisible();
   });

--- a/e2e/specs/login.test.js
+++ b/e2e/specs/login.test.js
@@ -9,27 +9,27 @@ test.describe('Login', () => {
   });
 
   test('User can login', async ({ page }) => {
-    await page.getByTestId('loginUsername').fill(E2E_TEST_USERNAME);
-    await page.getByTestId('loginPassword').fill(E2E_TEST_PASSWORD);
-    await page.getByTestId('loginSubmit').click();
+    await page.getByRole('textbox', { name: 'Username' }).fill(E2E_TEST_USERNAME);
+    await page.getByLabel('Password').fill(E2E_TEST_PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
     await page.getByTestId('toolbarMenuButton').click();
 
     await expect(page.getByTestId('toolbarMenuLogout')).toBeVisible();
   });
 
   test('Login with incorrect password (with valid, existing email)', async ({ page }) => {
-    await page.getByTestId('loginUsername').fill(E2E_TEST_USERNAME);
-    await page.getByTestId('loginPassword').fill('lol dummy pw');
-    await page.getByTestId('loginSubmit').click();
+    await page.getByRole('textbox', { name: 'Username' }).fill(E2E_TEST_USERNAME);
+    await page.getByLabel('Password').fill('lol dummy pw');
+    await page.getByRole('button', { name: 'Sign in' }).click();
 
-    await expect(page.getByTestId('loginError')).toContainText('Wrong email or password');
+    await expect(page.getByText('Wrong email or password')).toBeVisible();
   });
 
   test('Login with non-existing email', async ({ page }) => {
-    await page.getByTestId('loginUsername').fill('thisemail@isnotaregistereduser.com');
-    await page.getByTestId('loginPassword').fill('lol dummy pw');
-    await page.getByTestId('loginSubmit').click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('thisemail@isnotaregistereduser.com');
+    await page.getByLabel('Password').fill('lol dummy pw');
+    await page.getByRole('button', { name: 'Sign in' }).click();
 
-    await expect(page.getByTestId('loginError')).toContainText('Wrong email or password');
+    await expect(page.getByText('Wrong email or password')).toBeVisible();
   });
 });

--- a/e2e/specs/logout.test.js
+++ b/e2e/specs/logout.test.js
@@ -15,7 +15,7 @@ test.describe('Logout', () => {
 
     await page.getByTestId('confirm').click();
 
-    await expect(page.getByTestId('loginUsername')).toBeVisible();
+    await expect(page.getByRole('textbox', { name: 'Username' })).toBeVisible();
   });
 
   test('User can cancel log out in popup', async ({ page }) => {

--- a/e2e/utils/globalSetup.js
+++ b/e2e/utils/globalSetup.js
@@ -1,23 +1,33 @@
 const logFormat = require('../../assets/logFormat');
 const { chromium } = require('@playwright/test');
 
-const baseUrl = process.env.BROWSERSTACK
-  ? `http://${process.env.REACT_APP_FIREBASE_AUTHDOMAIN}`
-  : process.env.REACT_APP_FRONTEND || 'http://localhost:3000/';
+const {
+  E2E_TEST_USERNAME,
+  E2E_TEST_PASSWORD,
+  BROWSERSTACK,
+  BROWSERSTACK_USERNAME,
+  BROWSERSTACK_ACCESS_KEY,
+  REACT_APP_FIREBASE_AUTHDOMAIN,
+  REACT_APP_FRONTEND,
+} = process.env;
+
+const baseUrl = BROWSERSTACK
+  ? `http://${REACT_APP_FIREBASE_AUTHDOMAIN}`
+  : REACT_APP_FRONTEND || 'http://localhost:3000/';
 
 const checkEnv = async () => {
-  if (!process.env.E2E_TEST_USERNAME) {
+  if (!E2E_TEST_USERNAME) {
     console.log(`\t${logFormat.color.fg.red}Test account not defined${logFormat.clearFormat}
         Store the account username in the env variable ${logFormat.color.fg.green}E2E_TEST_USERNAME${logFormat.clearFormat} before executing the e2e tests`);
     process.exit(1);
   }
-  if (!process.env.E2E_TEST_PASSWORD) {
-    console.log(`\t${logFormat.color.fg.red}Password for ${process.env.E2E_TEST_USERNAME} not defined${logFormat.clearFormat}
+  if (!E2E_TEST_PASSWORD) {
+    console.log(`\t${logFormat.color.fg.red}Password for ${E2E_TEST_USERNAME} not defined${logFormat.clearFormat}
         Store the password in the env variable ${logFormat.color.fg.green}E2E_TEST_PASSWORD${logFormat.clearFormat} before executing the e2e tests`);
     process.exit(1);
   }
-  if (process.env.BROWSERSTACK) {
-    if (!process.env.BROWSERSTACK_USERNAME || !process.env.BROWSERSTACK_ACCESS_KEY) {
+  if (BROWSERSTACK) {
+    if (!BROWSERSTACK_USERNAME || !BROWSERSTACK_ACCESS_KEY) {
       console.log(`\t${logFormat.color.fg.red}Browserstack username and/or access key not defined${logFormat.clearFormat}
           Store the username/access key in the env variables ${logFormat.color.fg.green}BROWSERSTACK_USERNAME/BROWSERSTACK_ACCESS_KEY${logFormat.clearFormat}
           before executing the e2e:browserstack tests`);
@@ -30,9 +40,9 @@ const storeSignedInState = async () => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto(baseUrl);
-  await page.fill('[data-testid="loginUsername"]', process.env.E2E_TEST_USERNAME);
-  await page.fill('[data-testid="loginPassword"]', process.env.E2E_TEST_PASSWORD);
-  await page.click('[data-testid="loginSubmit"]');
+  await page.getByRole('textbox', { name: 'Username' }).fill(E2E_TEST_USERNAME);
+  await page.getByLabel('Password').fill(E2E_TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
   await page.waitForLoadState('networkidle');
   await page.context().storageState({ path: 'loggedIn.json' });
   await browser.close();

--- a/src/assets/gearFormRules.js
+++ b/src/assets/gearFormRules.js
@@ -3,6 +3,7 @@ import gearTypes from './gearTypes';
 
 const gearFormRules = {
   name: {
+    label: 'Name',
     elementType: 'input',
     elementConfig: {
       placeholder: 'Name',
@@ -14,9 +15,9 @@ const gearFormRules = {
     },
     valid: false,
     touched: false,
-    dataTestId: 'formGearName',
   },
   type: {
+    label: 'Type',
     elementType: 'select',
     elementConfig: {
       options: gearTypes,
@@ -28,9 +29,9 @@ const gearFormRules = {
     },
     valid: false,
     touched: false,
-    dataTestId: 'formGearType',
   },
   description: {
+    label: 'Description',
     elementType: 'textarea',
     elementConfig: {
       placeholder: 'Description',
@@ -41,9 +42,9 @@ const gearFormRules = {
       mandatory: false,
     },
     valid: true,
-    dataTestId: 'formGearDescription',
   },
   price: {
+    label: 'Price',
     elementType: 'input',
     elementConfig: {
       placeholder: 'Price',
@@ -54,7 +55,6 @@ const gearFormRules = {
       mandatory: false,
     },
     valid: true,
-    dataTestId: 'formGearPrice',
   },
 };
 

--- a/src/components/Authentication/Login/Login.js
+++ b/src/components/Authentication/Login/Login.js
@@ -11,7 +11,7 @@ const Login = ({ setPassword, setEmail, handleSwitchClick, handleSubmitButtonCli
   return(
     <Modal show={true}>
       <h1>Login plx</h1>
-      <p className='LoginError' data-testid='loginError'>{errorMsg}</p>
+      <p className='LoginError'>{errorMsg}</p>
       <form onSubmit={(event) => event.preventDefault()}>
         <Input
           label='Username'

--- a/src/components/Authentication/Login/Login.js
+++ b/src/components/Authentication/Login/Login.js
@@ -26,7 +26,7 @@ const Login = ({ setPassword, setEmail, handleSwitchClick, handleSubmitButtonCli
           <Switch
             orientation='horizontal'
             clicked={handleSwitchClick}
-            dataTestId='rememberMe'
+            label='Remember me'
             activated={true}/>
         </div>
         <Button

--- a/src/components/Authentication/Login/Login.js
+++ b/src/components/Authentication/Login/Login.js
@@ -14,13 +14,13 @@ const Login = ({ setPassword, setEmail, handleSwitchClick, handleSubmitButtonCli
       <p className='LoginError' data-testid='loginError'>{errorMsg}</p>
       <form onSubmit={(event) => event.preventDefault()}>
         <Input
+          label='Username'
           elementConfig={{ placeholder: 'Username (email)',type: 'email', autoComplete: 'on' }}
-          changed={(e) => setEmail(e.target.value)}
-          dataTestId='loginUsername'/>
+          changed={(e) => setEmail(e.target.value)}/>
         <Input
+          label='Password'
           elementConfig={{ placeholder: 'Password',type: 'password', autoComplete: 'on' }}
-          changed={(e) => setPassword(e.target.value)}
-          dataTestId='loginPassword'/>
+          changed={(e) => setPassword(e.target.value)}/>
         <div className='Remember'>
           Remember me
           <Switch

--- a/src/components/Authentication/Login/Login.test.js
+++ b/src/components/Authentication/Login/Login.test.js
@@ -17,18 +17,11 @@ describe('Login', () => {
     );
 
     // Assert that the Login component renders with the correct elements and attributes
-    const loginHeading = screen.getByRole('heading', { name: 'Login plx' });
-    const usernameInput = screen.getByTestId('loginUsername');
-    const passwordInput = screen.getByTestId('loginPassword');
-    const rememberMeSwitch = screen.getByTestId('rememberMe');
-    const submitButton = screen.getByTestId('loginSubmit');
-
-    expect(loginHeading).toBeInTheDocument();
-    expect(usernameInput).toBeInTheDocument();
-    expect(passwordInput).toBeInTheDocument();
-    expect(rememberMeSwitch).toBeInTheDocument();
-    expect(submitButton).toBeInTheDocument();
-    expect(submitButton).toBeDisabled();
+    expect(screen.getByRole('heading', { name: 'Login plx' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Username' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Remember me' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
   });
 
   test('calls the appropriate functions with correct values on form submission', () => {
@@ -51,14 +44,11 @@ describe('Login', () => {
     );
 
     // Enter values in the username and password input fields
-    const usernameInput = screen.getByTestId('loginUsername');
-    const passwordInput = screen.getByTestId('loginPassword');
-    fireEvent.change(usernameInput, { target: { value: 'test@test.com' } });
-    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Username' }), { target: { value: 'test@test.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
 
     // Click the submit button
-    const submitButton = screen.getByTestId('loginSubmit');
-    fireEvent.click(submitButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     // Assert that the appropriate functions are called with correct values
     expect(setEmailMock).toHaveBeenCalledWith('test@test.com');
@@ -82,8 +72,6 @@ describe('Login', () => {
     );
 
     // Assert that the error message is displayed
-    const errorElement = screen.getByTestId('loginError');
-    expect(errorElement).toBeInTheDocument();
-    expect(errorElement.textContent).toBe(errorMsg);
+    expect(screen.getByText(errorMsg)).toBeVisible();
   });
 });

--- a/src/components/UI/Input/Input.js
+++ b/src/components/UI/Input/Input.js
@@ -8,8 +8,8 @@ const Input = ({
   elementType = 'input',
   value = undefined,
   changed = () => {console.error(`no onChange handler function provided to ${elementType} component`);},
-  dataTestId = undefined,
   elementConfig = {},
+  label = '',
 }) => {
   let inputContent = null;
   const classes = ['InputElement'];
@@ -23,10 +23,10 @@ const Input = ({
     }
     const placeholderOption = value ? null : <option value='' disabled>{elementConfig.placeholder}</option>;
     inputContent = <select
+      aria-label={label}
       className={classes.join(' ')}
       value={value}
-      onChange={changed}
-      data-testid={dataTestId}>
+      onChange={changed}>
       {placeholderOption}
       {elementConfig.options.map(option => (
         <option key={option} value={option}>
@@ -37,10 +37,10 @@ const Input = ({
   } else {
     const CustomTag = elementType;
     inputContent = <CustomTag
+      aria-label={label}
       className={classes.join(' ')}
       value={value}
       onChange={changed}
-      data-testid={dataTestId}
       { ...elementConfig }/>;
   }
   return inputContent;

--- a/src/components/UI/Switch/Switch.js
+++ b/src/components/UI/Switch/Switch.js
@@ -5,14 +5,17 @@ const Switch = ({
   orientation = '',
   centered = false,
   activated = false,
-  dataTestId = undefined,
+  label='',
   clicked = () => {console.error('no onClick handler function provided to the Switch component');},
 }) => (
   <label
     className={['Switch', orientation].join(' ')}
-    style={centered ? { margin: 'auto' } : null}
-    data-testid={dataTestId}>
-    <input type='checkbox' defaultChecked={activated} onClick={clicked}/>
+    style={centered ? { margin: 'auto' } : null}>
+    <input
+      type='checkbox'
+      aria-label={label}
+      defaultChecked={activated}
+      onClick={clicked}/>
     <span className={['Slider', orientation].join(' ')}></span>
   </label>
 );

--- a/src/components/UI/Switch/Switch.test.js
+++ b/src/components/UI/Switch/Switch.test.js
@@ -10,18 +10,17 @@ describe('Switch', () => {
         orientation=''
         centered={false}
         activated={false}
-        dataTestId='testSwitch'
+        label='testSwitch'
         clicked={() => {}}
       />
     );
 
     // Assert that the Switch component renders with the correct elements and attributes
-    const switchLabel = screen.getByTestId('testSwitch');
     const switchInput = screen.getByRole('checkbox');
-    const switchSlider = screen.getByTestId('testSwitch'); // Update this line
+    const switchSlider = screen.getByLabelText('testSwitch');
 
-    expect(switchLabel).toBeInTheDocument();
     expect(switchInput).toBeInTheDocument();
+    expect(switchInput.closest('label')).toBeInTheDocument();
     expect(switchSlider).toBeInTheDocument();
     expect(switchInput).not.toBeChecked();
   });
@@ -36,7 +35,7 @@ describe('Switch', () => {
         orientation=''
         centered={false}
         activated={true}
-        dataTestId='testSwitch'
+        label='testSwitch'
         clicked={onClickMock}
       />
     );
@@ -56,13 +55,13 @@ describe('Switch', () => {
         orientation='horizontal'
         centered={true}
         activated={false}
-        dataTestId='testSwitch'
+        label='testSwitch'
         clicked={() => {}}
       />
     );
 
     // Assert that the Switch component renders with the correct classes and styles
-    const switchLabel = screen.getByTestId('testSwitch');
+    const switchLabel = screen.getByLabelText('testSwitch').closest('label');
     expect(switchLabel).toHaveClass('Switch horizontal');
     expect(switchLabel).toHaveStyle({ margin: 'auto' });
   });

--- a/src/containers/InstrumentDetails/InstrumentDetails.js
+++ b/src/containers/InstrumentDetails/InstrumentDetails.js
@@ -64,14 +64,14 @@ const InstrumentDetails = ({ userId }) => {
             submitInstrument={updateInstrument}
             closeModal={() => setEditingInstrument(false)}/>
         </Modal>
-        <div className={`PageContentBox ${instrument.type}`} data-testid='gearDetailsContentBox'>
-          <h1 className='PageContentHeader' data-testid='gearDetailsName'>{instrument.name}</h1>
-          <p data-testid='gearDetailsDescription'>
+        <div className={`PageContentBox ${instrument.type}`}>
+          <h1 className='PageContentHeader'>{instrument.name}</h1>
+          <p>
             {instrument.description}
           </p>
           { instrument.price
-            ? <p data-testid='price'>
-                Price: {instrument.price}
+            ? <p>
+                Price: {instrument.price} kr
             </p> : null }
         </div>
         <Modal show={deletingInstrument} modalClosed={() => setDeletingInstrument(false)}>

--- a/src/containers/InstrumentDetails/InstrumentDetails.test.js
+++ b/src/containers/InstrumentDetails/InstrumentDetails.test.js
@@ -31,10 +31,7 @@ test('Instrument info renders', async () => {
   const header = await screen.findByRole('heading', { level: 1 });
   expect(header).toHaveTextContent('Rickenbacker');
 
-  const description = screen.getByTestId('gearDetailsDescription');
-  expect(description).toHaveTextContent('A nice guitar');
-
-  const price = screen.getByTestId('price');
-  expect(price).toHaveTextContent(4000);
+  expect(screen.getByText('A nice guitar')).toBeVisible();
+  expect(screen.getByText('Price: 4000 kr')).toBeVisible();
 });
 

--- a/src/containers/InstrumentForm/InstrumentForm.js
+++ b/src/containers/InstrumentForm/InstrumentForm.js
@@ -73,6 +73,7 @@ const InstrumentForm = ({ instrument, submitInstrument, closeModal }) => {
       <form onSubmit={(event) => event.preventDefault()}>
         {formElementsArray.map(formElement => (
           <Input
+            label={formElement.config?.label}
             key={formElement.id}
             elementType={formElement.config.elementType}
             elementConfig={formElement.config.elementConfig}
@@ -80,7 +81,6 @@ const InstrumentForm = ({ instrument, submitInstrument, closeModal }) => {
             inValid={!formElement.config.valid}
             touched={formElement.config.touched}
             changed={(event) => handleInputChange(event, formElement.id)}
-            dataTestId={formElement.config.dataTestId}
           />
         ))}
       </form>

--- a/src/containers/InstrumentForm/InstrumentForm.js
+++ b/src/containers/InstrumentForm/InstrumentForm.js
@@ -70,6 +70,9 @@ const InstrumentForm = ({ instrument, submitInstrument, closeModal }) => {
   }
   return (
     <>
+      <h1>{instrument ? 'Edit' : 'Add'} Instrument
+
+      </h1>
       <form onSubmit={(event) => event.preventDefault()}>
         {formElementsArray.map(formElement => (
           <Input
@@ -87,8 +90,7 @@ const InstrumentForm = ({ instrument, submitInstrument, closeModal }) => {
       <Button
         disabled={!formValid}
         buttonType='Success'
-        clicked={handleSubmit}
-        dataTestId='submitGearFormButton'>
+        clicked={handleSubmit}>
         {instrument ? 'Update' : 'Add'}
       </Button>
       <Button

--- a/src/containers/InstrumentForm/InstrumentForm.test.js
+++ b/src/containers/InstrumentForm/InstrumentForm.test.js
@@ -13,29 +13,29 @@ describe('InstrumentForm component', () => {
   test('renders form elements', () => {
     render(<InstrumentForm submitInstrument={submitInstrumentMock} closeModal={closeModalMock} />);
 
-    expect(screen.getByTestId('formGearName')).toBeInTheDocument();
-    expect(screen.getByTestId('formGearType')).toBeInTheDocument();
-    expect(screen.getByTestId('formGearDescription')).toBeInTheDocument();
-    expect(screen.getByTestId('submitGearFormButton')).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Name' })).toBeVisible();
+    expect(screen.getByLabelText('Type')).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Description' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
   });
 
   test('populates form when rendered with instrument data', () => {
     const existingData = { type: 'guitar', name: 'My Guitar', description: 'cool one' };
     render(<InstrumentForm submitInstrument={submitInstrumentMock} closeModal={closeModalMock} instrument={existingData}/>);
 
-    expect(screen.getByTestId('formGearType')).toHaveValue('guitar');
-    expect(screen.getByTestId('formGearName')).toHaveValue('My Guitar');
-    expect(screen.getByTestId('formGearDescription')).toHaveValue('cool one');
+    expect(screen.getByLabelText('Type')).toHaveValue('guitar');
+    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('My Guitar');
+    expect(screen.getByRole('textbox', { name: 'Description' })).toHaveValue('cool one');
   });
 
   test('calls submitInstrument when form is submitted with valid inputs', () => {
     render(<InstrumentForm submitInstrument={submitInstrumentMock} closeModal={closeModalMock} />);
 
-    fireEvent.change(screen.getByTestId('formGearName'), { target: { value: 'Test gear name' } });
-    fireEvent.change(screen.getByTestId('formGearType'), { target: { value: 'guitar' } });
-    fireEvent.change(screen.getByTestId('formGearDescription'), { target: { value: 'Test description' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Test gear name' } });
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'guitar' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Description' }), { target: { value: 'Test description' } });
 
-    fireEvent.click(screen.getByTestId('submitGearFormButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     expect(submitInstrumentMock).toHaveBeenCalledWith({
       name: 'Test gear name',

--- a/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.js
+++ b/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.js
@@ -70,7 +70,7 @@ const InstrumentListActions = ({
                   centered
                   activated={activeFilter.includes(gearType)}
                   clicked={() => updateFilter(gearType)}
-                  dataTestId={`${gearType}-filter`}/>
+                  label={`${gearType}-filter`}/>
                 {gearType}
               </div>
             );

--- a/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.test.js
+++ b/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.test.js
@@ -40,7 +40,7 @@ describe('InstrumentListActions component', () => {
 
   test('clicking a filter switch calls updateFilter function', () => {
     fireEvent.click(screen.getByTestId('filterButton'));
-    fireEvent.click(screen.getByTestId('guitar-filter'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'guitar-filter' }));
     expect(updateFilter).toHaveBeenCalledTimes(1);
     expect(updateFilter).toHaveBeenCalledWith('guitar');
   });


### PR DESCRIPTION
This PR starts the effort of removing testID usage in favour for accessibility improvements. Basically swapping testID:s for accessible labels for elements.

In the PR, I focus on the `Input` and `Switch` component. Took the liberty of removing some other testID usage in the components using these UI component and thus needed to be updated.


Resolves #184 
Resolves #185 