### PR TITLE
Clean out testids for iconbuttons

### DIFF
--- a/e2e/specs/gearList.test.js
+++ b/e2e/specs/gearList.test.js
@@ -14,11 +14,11 @@ test.describe('Gear list', () => {
   });
 
   test('Add new instrument', async ({ page }) => {
-    await page.getByTestId('addNewInstrumentButton').click();
+    await page.getByRole('button', { name: 'Add new instrument' }).click();
     await page.getByLabel('Type').selectOption('bass');
     await page.getByRole('textbox', { name: 'Name' }).fill(name);
     await page.getByRole('textbox', { name: 'Description' }).fill('Gear description');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
 
     await expect(page.getByRole('row', { name })).toBeVisible();
   });

--- a/e2e/specs/login.test.js
+++ b/e2e/specs/login.test.js
@@ -12,7 +12,7 @@ test.describe('Login', () => {
     await page.getByRole('textbox', { name: 'Username' }).fill(E2E_TEST_USERNAME);
     await page.getByLabel('Password').fill(E2E_TEST_PASSWORD);
     await page.getByRole('button', { name: 'Sign in' }).click();
-    await page.getByTestId('toolbarMenuButton').click();
+    await page.getByRole('button', { name: 'Toolbar menu' }).click();
 
     await expect(page.getByTestId('toolbarMenuLogout')).toBeVisible();
   });

--- a/e2e/specs/logout.test.js
+++ b/e2e/specs/logout.test.js
@@ -7,7 +7,7 @@ test.describe('Logout', () => {
   });
 
   test('User can log out', async ({ page }) => {
-    await page.getByTestId('toolbarMenuButton').click();
+    await page.getByRole('button', { name: 'Toolbar menu' }).click();
     await page.getByTestId('toolbarMenuLogout').click();
 
     const confirmElement = await page.getByRole('button', { name: 'Yes' }).elementHandle();
@@ -19,10 +19,10 @@ test.describe('Logout', () => {
   });
 
   test('User can cancel log out in popup', async ({ page }) => {
-    await page.getByTestId('toolbarMenuButton').click();
+    await page.getByRole('button', { name: 'Toolbar menu' }).click();
     await page.getByTestId('toolbarMenuLogout').click();
     await page.getByRole('button', { name: 'No' }).click();
-    await page.getByTestId('toolbarMenuButton').click();
+    await page.getByRole('button', { name: 'Toolbar menu' }).click();
 
     await expect(page.getByTestId('toolbarMenuLogout')).toBeVisible();
 

--- a/src/components/Navigation/Toolbar/Toolbar.js
+++ b/src/components/Navigation/Toolbar/Toolbar.js
@@ -31,7 +31,7 @@ const Toolbar = ({ showMenu, toggleMenu, logout }) => {
           id='menuButton'
           active={showMenu}
           clicked={() => toggleMenu(!showMenu)}
-          dataTestId='toolbarMenuButton'/>
+          label='Toolbar menu'/>
         <div className='ToolbarMenuContainer'>
           <Transition show={showMenu}>
             <ToolbarMenu handleMenuChoice={handleMenuChoice}/>

--- a/src/components/Navigation/Toolbar/Toolbar.test.js
+++ b/src/components/Navigation/Toolbar/Toolbar.test.js
@@ -27,7 +27,7 @@ describe('Toolbar', () => {
         />
       </BrowserRouter>
     );
-    expect(screen.getByTestId('toolbarMenuButton')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toolbar menu' })).toBeInTheDocument();
   });
 
   test('should toggle menu on button click', () => {
@@ -40,7 +40,7 @@ describe('Toolbar', () => {
         />
       </BrowserRouter>
     );
-    fireEvent.click(screen.getByTestId('toolbarMenuButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Toolbar menu' }));
     expect(toggleMenuSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/UI/IconButton/IconButton.css
+++ b/src/components/UI/IconButton/IconButton.css
@@ -1,4 +1,5 @@
 .IconButton {
+  all: unset;
   padding: 1px 5px;
   font-size: 1.5rem;
   transition: all 0.2s;

--- a/src/components/UI/IconButton/IconButton.js
+++ b/src/components/UI/IconButton/IconButton.js
@@ -2,13 +2,14 @@ import React from 'react';
 import './IconButton.css';
 
 const IconButton = props => (
-  <div
+  <button
+    type='button'
     className={`IconButton${props.active ? ' Active' : ''}`}
     onClick={props.clicked}
     id={props.id}
-    data-testid={props.dataTestId}>
+    aria-label={props.label}>
     <i className={props.type}></i>
-  </div>
+  </button>
 );
 
 export default IconButton;

--- a/src/components/UI/IconButton/IconButton.test.js
+++ b/src/components/UI/IconButton/IconButton.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import IconButton from './IconButton';
 
 describe('IconButton Component', () => {
@@ -10,59 +10,59 @@ describe('IconButton Component', () => {
   });
 
   test('renders an icon button with correct type class', () => {
-    const { getByTestId } = render(
+    render(
       <IconButton
         type="fa fa-heart"
-        dataTestId="icon-button"
+        label="icon-button"
         clicked={clickHandler}
       />
     );
 
-    const iconButton = getByTestId('icon-button');
+    const iconButton = screen.getByRole('button', { name: 'icon-button' });
     expect(iconButton).toBeInTheDocument();
     expect(iconButton.querySelector('.fa.fa-heart')).toBeInTheDocument();
   });
 
   test('calls the clicked function when clicked', () => {
-    const { getByTestId } = render(
+    render(
       <IconButton
         type="fa fa-heart"
-        dataTestId="icon-button"
+        label="icon-button"
         clicked={clickHandler}
       />
     );
 
-    const iconButton = getByTestId('icon-button');
+    const iconButton = screen.getByRole('button', { name: 'icon-button' });
     fireEvent.click(iconButton);
 
     expect(clickHandler).toHaveBeenCalledTimes(1);
   });
 
   test('has active class when active prop is true', () => {
-    const { getByTestId } = render(
+    render(
       <IconButton
         type="fa fa-heart"
-        dataTestId="icon-button"
+        label="icon-button"
         active={true}
         clicked={clickHandler}
       />
     );
 
-    const iconButton = getByTestId('icon-button');
+    const iconButton = screen.getByRole('button', { name: 'icon-button' });
     expect(iconButton).toHaveClass('Active');
   });
 
   test('does not have active class when active prop is false', () => {
-    const { getByTestId } = render(
+    render(
       <IconButton
         type="fa fa-heart"
-        dataTestId="icon-button"
+        label="icon-button"
         active={false}
         clicked={clickHandler}
       />
     );
 
-    const iconButton = getByTestId('icon-button');
+    const iconButton = screen.getByRole('button', { name: 'icon-button' });
     expect(iconButton).not.toHaveClass('Active');
   });
 });

--- a/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.js
+++ b/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.js
@@ -44,7 +44,7 @@ const InstrumentListActions = ({
             active={showFilter}
             clicked={() => {setShowFilter(!showFilter);}}
             id='FilterButton'
-            dataTestId='filterButton'/>
+            label='Filter'/>
           <Transition orientation='South' show={activeFilter.length !== gearTypes.length}>
             <div
               style={{ alignSelf: 'center', marginLeft: '5px', cursor: 'pointer' }}
@@ -56,7 +56,7 @@ const InstrumentListActions = ({
         <IconButton
           type='fa fa-plus'
           clicked={addInstrument}
-          dataTestId='addNewInstrumentButton'/>
+          label='Add new instrument'/>
       </div>
       <Transition show={showFilter}>
         <div //TODO: make the dropdown a component of its own

--- a/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.test.js
+++ b/src/containers/InstrumentList/InstrumentListActions/InstrumentListActions.test.js
@@ -24,7 +24,7 @@ describe('InstrumentListActions component', () => {
   });
 
   test('clicking filter button shows filter dropdown', () => {
-    fireEvent.click(screen.getByTestId('filterButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
     expect(screen.getByTestId('filterDropdown')).toBeInTheDocument();
   });
 
@@ -34,12 +34,12 @@ describe('InstrumentListActions component', () => {
   });
 
   test('clicking add instrument button calls addInstrument function', () => {
-    fireEvent.click(screen.getByTestId('addNewInstrumentButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add new instrument' }));
     expect(addInstrument).toHaveBeenCalledTimes(1);
   });
 
   test('clicking a filter switch calls updateFilter function', () => {
-    fireEvent.click(screen.getByTestId('filterButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'guitar-filter' }));
     expect(updateFilter).toHaveBeenCalledTimes(1);
     expect(updateFilter).toHaveBeenCalledWith('guitar');


### PR DESCRIPTION
This PR improves IconButton accessibility with the following changes:

- Make it an acctual button
- Update css accordingly to not affect UI looks
- Add aria-label since the icon button does not have any text
- Remove support for data-testid

Components using the button have deen updated accordingly as well as tests.


Resolves #190 