### PR TITLE
Improve Modal and Backdrop accessibility

### DIFF
--- a/e2e/specs/gearDetails.test.js
+++ b/e2e/specs/gearDetails.test.js
@@ -30,7 +30,7 @@ test.describe('Gear details page', () => {
     await page.getByRole('textbox', { name: 'Description' }).fill('updated description');
     await page.getByRole('button', { name: 'Update' }).click();
 
-    await expect(page.getByRole('heading', { level: 1 })).toHaveText('updated name');
+    await expect(page.getByRole('heading', { name: 'updated name', exact: true })).toBeVisible();
     await expect(page.getByText('updated description')).toBeVisible();
   });
 

--- a/src/App.js
+++ b/src/App.js
@@ -78,8 +78,11 @@ const App = () => {
       <SettingsProvider>
         <Layout
           logout={() => setLoggingOut(true)}>
-          <Modal show={loggingOut} modalClosed={() => setLoggingOut(false)}>
-            <ConfirmChoice title={'Logging out...'} confirm={logout} reject={() => setLoggingOut(false)}/>
+          <Modal
+            show={loggingOut}
+            modalClosed={() => setLoggingOut(false)}
+            title='Logging out...'>
+            <ConfirmChoice confirm={logout} reject={() => setLoggingOut(false)}/>
           </Modal>
           {appContent}
         </Layout>

--- a/src/components/Authentication/Login/Login.js
+++ b/src/components/Authentication/Login/Login.js
@@ -9,8 +9,7 @@ import './Login.css';
 const Login = ({ setPassword, setEmail, handleSwitchClick, handleSubmitButtonClick, errorMsg, formValid }) => {
 
   return(
-    <Modal show={true}>
-      <h1>Login plx</h1>
+    <Modal show={true} title='Login plx'>
       <p className='LoginError'>{errorMsg}</p>
       <form onSubmit={(event) => event.preventDefault()}>
         <Input

--- a/src/components/Navigation/ConfirmChoice/ConfirmChoice.js
+++ b/src/components/Navigation/ConfirmChoice/ConfirmChoice.js
@@ -2,9 +2,8 @@ import React from 'react';
 import Button from '../../UI/Button/Button';
 import './ConfirmChoice.css';
 
-const ConfirmChoice = ({ title, confirm, reject }) => (
-  <React.Fragment>
-    <h2 className='ConfirmTitle'>{title}</h2>
+const ConfirmChoice = ({ confirm, reject }) => (
+  <>
     <h4>Are you sure?</h4>
     <Button buttonType='Danger' clicked={confirm}>
       Yes
@@ -12,7 +11,7 @@ const ConfirmChoice = ({ title, confirm, reject }) => (
     <Button clicked={reject}>
       No
     </Button>
-  </React.Fragment>
+  </>
 );
 
 export default ConfirmChoice;

--- a/src/components/Navigation/ConfirmChoice/ConfirmChoice.test.js
+++ b/src/components/Navigation/ConfirmChoice/ConfirmChoice.test.js
@@ -3,9 +3,8 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import ConfirmChoice from './ConfirmChoice';
 
 describe('ConfirmChoice', () => {
-  it('should render the title and confirmation message', () => {
-    render(<ConfirmChoice title="Test Confirmation" />);
-    expect(screen.getByText('Test Confirmation')).toBeInTheDocument();
+  it('should render the confirmation message', () => {
+    render(<ConfirmChoice/>);
     expect(screen.getByText('Are you sure?')).toBeInTheDocument();
   });
 

--- a/src/components/UI/Backdrop/Backdrop.js
+++ b/src/components/UI/Backdrop/Backdrop.js
@@ -3,7 +3,14 @@ import React from 'react';
 import './Backdrop.css';
 
 const backdrop = ({ show, clicked }) => (
-  show ? <div className="Backdrop" onClick={clicked} data-testid='backdrop'></div> : null
+  show ? (
+    <div
+      role='presentation'
+      className="Backdrop"
+      onClick={clicked}
+      aria-hidden="true"
+    />
+  ) : null
 );
 
 export default backdrop;

--- a/src/components/UI/Backdrop/Backdrop.test.js
+++ b/src/components/UI/Backdrop/Backdrop.test.js
@@ -1,24 +1,24 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import Backdrop from './Backdrop';
 
 describe('Backdrop', () => {
   test('renders correctly with show prop as true', () => {
     // Render the Backdrop component with show prop as true
-    render(<Backdrop show={true} clicked={() => {}} />);
+    const { container } = render(<Backdrop show={true} clicked={() => {}} />);
 
     // Assert that the Backdrop component renders with the correct element and class
-    const backdropElement = screen.getByTestId('backdrop');
+    const backdropElement = container.querySelector('.Backdrop');
     expect(backdropElement).toBeInTheDocument();
     expect(backdropElement).toHaveClass('Backdrop');
   });
 
   test('renders correctly with show prop as false', () => {
     // Render the Backdrop component with show prop as false
-    render(<Backdrop show={false} clicked={() => {}} />);
+    const { container } = render(<Backdrop show={false} clicked={() => {}} />);
 
     // Assert that the Backdrop component does not render any element
-    const backdropElement = screen.queryByTestId('backdrop');
+    const backdropElement = container.querySelector('.Backdrop');
     expect(backdropElement).toBeNull();
   });
 
@@ -27,10 +27,10 @@ describe('Backdrop', () => {
     const onClickMock = jest.fn();
 
     // Render the Backdrop component with mock callback
-    render(<Backdrop show={true} clicked={onClickMock} />);
+    const { container } = render(<Backdrop show={true} clicked={onClickMock} />);
 
     // Click the backdrop element
-    const backdropElement = screen.getByTestId('backdrop');
+    const backdropElement = container.querySelector('.Backdrop');
     fireEvent.click(backdropElement);
 
     // Assert that the onClick callback function is called

--- a/src/components/UI/Modal/Modal.js
+++ b/src/components/UI/Modal/Modal.js
@@ -8,7 +8,7 @@ const Modal = ({
   show = true,
   modalClosed = () => null,
   children,
-  dataTestId = undefined,
+  title = '',
 }) => {
   const escFunction = React.useCallback((event) => {
     if(event.keyCode === 27) {
@@ -29,11 +29,16 @@ const Modal = ({
     <React.Fragment>
       <Backdrop show={show} clicked={modalClosed} />
       <div
+        role='dialog'
+        aria-modal='true'
+        aria-labelledby="modal-title"
         className="Modal"
         style={{
           transform: show ? 'scale(1)' : 'scale(0)',
-          opacity: show ? '1' : '0' }}
-        data-testid={dataTestId}>
+          opacity: show ? '1' : '0' }}>
+        <h1 id='modal-title'>
+          {title}
+        </h1>
         {show ? children : null}
       </div>
     </React.Fragment>

--- a/src/components/UI/Modal/Modal.test.js
+++ b/src/components/UI/Modal/Modal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import Modal from './Modal';
 
 describe('Modal Component', () => {
@@ -10,48 +10,48 @@ describe('Modal Component', () => {
   });
 
   it('renders modal with children when show prop is true', () => {
-    const { getByTestId, queryByText } = render(
-      <Modal show={true} modalClosed={modalClosedMock} dataTestId="modal">
+    render(
+      <Modal show={true} modalClosed={modalClosedMock}>
         <div>Modal Content</div>
       </Modal>
     );
 
-    const modal = getByTestId('modal');
+    const modal = screen.getByRole('dialog');
     expect(modal).toBeInTheDocument();
-    expect(queryByText('Modal Content')).toBeInTheDocument();
+    expect(screen.queryByText('Modal Content')).toBeInTheDocument();
   });
 
   it('does not render modal with children when show prop is false', () => {
-    const { queryByText } = render(
-      <Modal show={false} modalClosed={modalClosedMock} dataTestId="modal">
+    render(
+      <Modal show={false} modalClosed={modalClosedMock}>
         <div>Modal Content</div>
       </Modal>
     );
 
-    expect(queryByText('Modal Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Modal Content')).not.toBeInTheDocument();
   });
 
   it('calls modalClosed function when backdrop is clicked', () => {
-    const { getByTestId } = render(
-      <Modal show={true} modalClosed={modalClosedMock} dataTestId="modal">
+    const { container } = render(
+      <Modal show={true} modalClosed={modalClosedMock}>
         <div>Modal Content</div>
       </Modal>
     );
 
-    const backdrop = getByTestId('backdrop');
+    const backdrop = container.querySelector('.Backdrop');
     fireEvent.click(backdrop);
 
     expect(modalClosedMock).toHaveBeenCalledTimes(1);
   });
 
   it('calls modalClosed function when escape key is pressed', () => {
-    const { getByTestId } = render(
-      <Modal show={true} modalClosed={modalClosedMock} dataTestId="modal">
+    render(
+      <Modal show={true} modalClosed={modalClosedMock}>
         <div>Modal Content</div>
       </Modal>
     );
 
-    const modal = getByTestId('modal');
+    const modal = screen.getByRole('dialog');
     fireEvent.keyDown(modal, { keyCode: 27 });
 
     expect(modalClosedMock).toHaveBeenCalledTimes(1);

--- a/src/containers/InstrumentDetails/InstrumentDetails.js
+++ b/src/containers/InstrumentDetails/InstrumentDetails.js
@@ -43,7 +43,7 @@ const InstrumentDetails = ({ userId }) => {
   if (error) {
     content = (
       <>
-        <Modal>
+        <Modal title='Error'>
           <h3>
             {error.message}
           </h3>
@@ -58,7 +58,10 @@ const InstrumentDetails = ({ userId }) => {
     // adding the type to the class name is primarily to help the e2e tests. When further developing, this should be indintifyable in some other way...
     content = (
       <>
-        <Modal show={editingInstrument} modalClosed={() => setEditingInstrument(false)}>
+        <Modal
+          show={editingInstrument}
+          modalClosed={() => setEditingInstrument(false)}
+          title={`Edit ${instrument.name}`}>
           <InstrumentForm
             instrument={instrument}
             submitInstrument={updateInstrument}
@@ -74,8 +77,11 @@ const InstrumentDetails = ({ userId }) => {
                 Price: {instrument.price} kr
             </p> : null }
         </div>
-        <Modal show={deletingInstrument} modalClosed={() => setDeletingInstrument(false)}>
-          <ConfirmChoice title={`Delete ${instrument.name}`} confirm={deleteInstrument} reject={() => setDeletingInstrument(false)}/>
+        <Modal
+          show={deletingInstrument}
+          modalClosed={() => setDeletingInstrument(false)}
+          title={`Delete ${instrument.name}`}>
+          <ConfirmChoice confirm={deleteInstrument} reject={() => setDeletingInstrument(false)}/>
         </Modal>
         <Button clicked={() => navigate(-1)}>
         Back

--- a/src/containers/InstrumentDetails/InstrumentDetails.test.js
+++ b/src/containers/InstrumentDetails/InstrumentDetails.test.js
@@ -34,21 +34,19 @@ beforeEach(() => {
 });
 
 test('Instrument info renders', async () => {
-  const header = await screen.findByRole('heading', { level: 1 });
-  expect(header).toHaveTextContent('Rickenbacker');
-
+  expect(await screen.findByRole('heading', { name: 'Rickenbacker' })).toBeVisible();
   expect(screen.getByText('A nice guitar')).toBeVisible();
   expect(screen.getByText('Price: 4000 kr')).toBeVisible();
 });
 
-test('Clicking edit button activates instrument edit', async () => {
+test('Clicking delete button activates instrument delete', async () => {
   userEvent.click(screen.getByRole('button', { name: 'Delete' }));
   expect(await screen.findByRole('heading', { name: 'Delete Rickenbacker' })).toBeVisible();
 });
 
-test('Clicking delete button activates instrument delete', async () => {
+test('Clicking edit button activates instrument edit', async () => {
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-  expect(await screen.findByRole('heading', { name: 'Edit Instrument' })).toBeVisible();
+  expect(await screen.findByRole('heading', { name: 'Edit Rickenbacker' })).toBeVisible();
 });
 
 test('Clicking back button navigates user back', async () => {

--- a/src/containers/InstrumentForm/InstrumentForm.js
+++ b/src/containers/InstrumentForm/InstrumentForm.js
@@ -70,9 +70,6 @@ const InstrumentForm = ({ instrument, submitInstrument, closeModal }) => {
   }
   return (
     <>
-      <h1>{instrument ? 'Edit' : 'Add'} Instrument
-
-      </h1>
       <form onSubmit={(event) => event.preventDefault()}>
         {formElementsArray.map(formElement => (
           <Input

--- a/src/containers/InstrumentList/InstrumentList.js
+++ b/src/containers/InstrumentList/InstrumentList.js
@@ -85,7 +85,10 @@ const InstrumentList = ({ userId }) => {
   }
 
   const addInstrumentModal = (
-    <Modal show={addingInstrument} modalClosed={() => setAddingInstrument(false)}>
+    <Modal
+      show={addingInstrument}
+      modalClosed={() => setAddingInstrument(false)}
+      title='Add instrument'>
       <InstrumentForm
         submitInstrument={addInstrument}
         closeModal={() => setAddingInstrument(false)}/>


### PR DESCRIPTION
The Accessibility has been improved for these components with the following changes:

## Updates
- Backdrop now has the `aria-hidden="true"` attribute to not confuse screen readers etc.
- Modal
  - Titles for modals are now handled directly in the Modal by passing it as a prop. This has the following advantages:
    - Consistency: All modal headers will look the same and will be handled in one place instead of scattered all over the place with different solutions for different cases
    - Accessibility: The title can be (and is as of this PR) tied to the modal with the `aria-labelledby` attribute
- All testID support has been removed from the components

## Cleanup/adjustments
- All components using the Modal has been updated according to the changes. 
  - Not handling titles elsewhere
  - Pass title to modal
- Test has been updated to reflect the changes and to use accessibility-oriented locators for these Components instead of test ID:s 