### PR TITLE
Create auth context provider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Route, Routes, useNavigate } from 'react-router-dom';
-import { getAuth, signInWithEmailAndPassword, setPersistence, browserLocalPersistence, browserSessionPersistence, signOut } from 'firebase/auth';
-import { useAuthState } from 'react-firebase-hooks/auth';
+import React from 'react';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import Login from './components/Authentication/Login/Login';
 import InstrumentList from './containers/InstrumentList/InstrumentList';
 import InstrumentDetails from './containers/InstrumentDetails/InstrumentDetails';
@@ -11,80 +9,64 @@ import Spinner from './components/UI/Spinner/Spinner';
 import Modal from './components/UI/Modal/Modal';
 import ConfirmChoice from './components/Navigation/ConfirmChoice/ConfirmChoice';
 import { SettingsProvider } from './hoc/Context/SettingsContext';
-import firebase from './firebase';
+import { useAuth } from './hoc/Context/AuthContext';
+import ProtectedRoute from './hoc/ProtectedRoute/ProtectedRoute';
 import './App.css';
 
-const auth = getAuth(firebase);
+const AppContent = () => {
+  const { user, loading } = useAuth();
 
-const App = () => {
-  const [rememberMe, setRememberMe] = useState(true);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [user, loading, error] = useAuthState(auth);
-  const [loggingOut, setLoggingOut] = useState(false);
-  const [loginError, setLoginError] = useState('');
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (loading) return;
-    if (error) console.error(error);
-    if (!user) navigate('/login');
-  }, [user, loading, error, navigate]);
-
-  const handleRememberMeSwitchClick = () => setRememberMe(!rememberMe);
-
-  const login = async () => {
-    rememberMe
-      ? await setPersistence(auth, browserLocalPersistence)
-      : await setPersistence(auth, browserSessionPersistence);
-    try {
-      await signInWithEmailAndPassword(auth, email, password);
-      navigate('/');
-      setLoginError('');
-    } catch (err) {
-      if (err.code === 'auth/user-not-found' || err.code === 'auth/wrong-password') setLoginError('Wrong email or password');
-      else if (err.code === 'auth/invalid-email') setLoginError('You need to enter a valid email address');
-      else setLoginError(err.code);
-    }
-  };
-
-  const logout = async () => {
-    if (user) {
-      try {
-        await signOut(auth);
-      } catch(err) { console.error(err); }
-      setLoggingOut(false);
-    }
-  };
-
-  const appContent = loading
-    ? <Spinner />
-    : <Routes>
-      <Route path='/login' element={
-        <Login
-          setEmail={setEmail}
-          setPassword={setPassword}
-          handleSubmitButtonClick={login}
-          handleSwitchClick={handleRememberMeSwitchClick}
-          errorMsg={loginError}
-          formValid={email.match(/^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/) && password !== ''}/>}/>
-      <Route path='/gearitem' element={<InstrumentDetails userId={user?.uid}/>}/>
-      <Route path='/settings' element={<Settings/>} />
-      <Route path='/' element={<InstrumentList userId={user?.uid}/>}/>
-    </Routes>;
+  if (loading) return <Spinner />;
 
   return (
-    <div className="App">
+    <Routes>
+      <Route path='/login' element={<Login />} />
+      <Route
+        path='/'
+        element={
+          <ProtectedRoute>
+            <InstrumentList userId={user?.uid} />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path='/gearitem'
+        element={
+          <ProtectedRoute>
+            <InstrumentDetails userId={user?.uid} />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path='/settings'
+        element={
+          <ProtectedRoute>
+            <Settings />
+          </ProtectedRoute>
+        }
+      />
+      {/* Catch-all redirect */}
+      <Route path='*' element={<Navigate to='/' replace />} />
+    </Routes>
+  );
+};
+
+const App = () => {
+  const [loggingOut, setLoggingOut] = React.useState(false);
+  const { logout } = useAuth();
+
+  return (
+    <div className='App'>
       <SettingsProvider>
-        <Layout
-          logout={() => setLoggingOut(true)}>
+        <Layout logout={() => setLoggingOut(true)}>
           <Modal
             show={loggingOut}
             modalClosed={() => setLoggingOut(false)}
-            title='Logging out...'>
-            <ConfirmChoice confirm={logout} reject={() => setLoggingOut(false)}/>
+            title='Logging out...'
+          >
+            <ConfirmChoice confirm={async () => { await logout(); setLoggingOut(false); }} reject={() => setLoggingOut(false)} />
           </Modal>
-          {appContent}
+          <AppContent />
         </Layout>
       </SettingsProvider>
     </div>

--- a/src/components/Authentication/Login/Login.js
+++ b/src/components/Authentication/Login/Login.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useAuth } from '../../../hoc/Context/AuthContext';
 import Modal from '../../UI/Modal/Modal';
 import Input from '../../UI/Input/Input';
 import Button from '../../UI/Button/Button';
@@ -6,36 +7,49 @@ import Switch from '../../UI/Switch/Switch';
 
 import './Login.css';
 
-const Login = ({ setPassword, setEmail, handleSwitchClick, handleSubmitButtonClick, errorMsg, formValid }) => {
+const Login = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
 
-  return(
+  const { login, loginError } = useAuth(); // <-- context values
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login(email, password, rememberMe);
+  };
+
+  return (
     <Modal show={true} title='Login plx'>
-      <p className='LoginError'>{errorMsg}</p>
-      <form onSubmit={(event) => event.preventDefault()}>
+      {loginError && <p className='LoginError'>{loginError}</p>}
+      <form onSubmit={handleSubmit}>
         <Input
           label='Username'
-          elementConfig={{ placeholder: 'Username (email)',type: 'email', autoComplete: 'on' }}
-          changed={(e) => setEmail(e.target.value)}/>
+          elementConfig={{ placeholder: 'Username (email)', type: 'email', autoComplete: 'on' }}
+          changed={(e) => setEmail(e.target.value)}
+        />
         <Input
           label='Password'
-          elementConfig={{ placeholder: 'Password',type: 'password', autoComplete: 'on' }}
-          changed={(e) => setPassword(e.target.value)}/>
+          elementConfig={{ placeholder: 'Password', type: 'password', autoComplete: 'on' }}
+          changed={(e) => setPassword(e.target.value)}
+        />
         <div className='Remember'>
           Remember me
           <Switch
             orientation='horizontal'
-            clicked={handleSwitchClick}
+            clicked={() => setRememberMe(!rememberMe)}
             label='Remember me'
-            activated={true}/>
+            activated={rememberMe}
+          />
         </div>
         <Button
-          disabled={!formValid}
-          clicked={handleSubmitButtonClick}>
+          disabled={!email || !password}
+          clicked={handleSubmit}
+        >
           Sign in
         </Button>
       </form>
     </Modal>
-
   );
 };
 

--- a/src/containers/InstrumentDetails/InstrumentDetails.js
+++ b/src/containers/InstrumentDetails/InstrumentDetails.js
@@ -24,7 +24,7 @@ const InstrumentDetails = ({ userId }) => {
       if (data) setInstrument({ id, ...data });
       else setError(new Error('Gear item couldn\'t be found in database'));
     },
-    (err) => navigate('/login') // TODO: when adding id specific db path, investigate if this should be tweaked if loggedin user tries to get other user's stuff...
+    (err) => setError(err)
     );
     return () => off(databaseRef);
   },[location.search, db, navigate, userId]);

--- a/src/hoc/Context/AuthContext.js
+++ b/src/hoc/Context/AuthContext.js
@@ -1,0 +1,93 @@
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut,
+  setPersistence,
+  browserLocalPersistence,
+  browserSessionPersistence,
+} from 'firebase/auth';
+import firebase from '../../firebase';
+import { useNavigate } from 'react-router-dom';
+
+// 1. Create context
+const AuthContext = createContext({
+  user: null,
+  loading: true,
+  login: async () => {},
+  logout: async () => {},
+});
+
+// 2. Provider component
+export const AuthProvider = ({ children }) => {
+  const auth = getAuth(firebase);
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [loginError, setLoginError] = useState('');
+  const navigate = useNavigate();
+  // Listen for auth state changes
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (firebaseUser) => {
+        setUser(firebaseUser);
+        setLoading(false);
+      },
+      (err) => {
+        console.error(err);
+        setError(err);
+        setLoading(false);
+      }
+    );
+    return unsubscribe;
+  }, [auth]);
+
+  // login helper
+  const login = useCallback(async (email, password, rememberMe) => {
+    try {
+      setLoginError('');
+      await setPersistence(
+        auth,
+        rememberMe ? browserLocalPersistence : browserSessionPersistence
+      );
+      await signInWithEmailAndPassword(auth, email, password);
+      return navigate('/');
+    } catch (err) {
+      if (err.code === 'auth/user-not-found' || err.code === 'auth/wrong-password') {
+        setLoginError('Wrong email or password');
+      } else if (err.code === 'auth/invalid-email') {
+        setLoginError('You need to enter a valid email address');
+      } else {
+        setLoginError(err.message);
+      }
+      setError(err);
+      throw err;
+    }
+  }, [auth, navigate]);
+
+  // logout helper
+  const logout = useCallback(async () => {
+    try {
+      await signOut(auth);
+    } catch (err) {
+      console.error(err);
+      setError(err);
+    }
+  }, [auth]);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, error, loginError, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// 3. Hook for consuming
+export const useAuth = () => {
+  return useContext(AuthContext);
+};
+
+// Exporting the AuthContext to be usable by wrappers in tests
+export { AuthContext };

--- a/src/hoc/Context/AuthContext.js
+++ b/src/hoc/Context/AuthContext.js
@@ -29,7 +29,7 @@ export const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
   // Listen for auth state changes
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(
+    return onAuthStateChanged(
       auth,
       (firebaseUser) => {
         setUser(firebaseUser);
@@ -41,7 +41,6 @@ export const AuthProvider = ({ children }) => {
         setLoading(false);
       }
     );
-    return unsubscribe;
   }, [auth]);
 
   // login helper

--- a/src/hoc/ProtectedRoute/ProtectedRoute.js
+++ b/src/hoc/ProtectedRoute/ProtectedRoute.js
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../Context/AuthContext';
+
+const ProtectedRoute = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) return null; // or a Spinner
+
+  return user ? children : <Navigate to='/login' replace />;
+};
+
+export default ProtectedRoute;

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,15 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import { AuthProvider } from './hoc/Context/AuthContext';
+
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),


### PR DESCRIPTION
Resolves #181 

In this PR, I've moved auth and login logic out of `App.js` into an AuthContext provider component that wraps the App.
I've also added A `ProtectedRoute` hoc to protect auth-required routes.

Benefits of this approach:
- Separation of Concerns: Auth logic is isolated in AuthContextProvider, keeping App.js focused routing.
- Reusability: Any component can access auth state/actions via useAuth()—no more prop drilling.
- Cleaner Route Protection: ProtectedRoute centralizes auth checks instead of scattering user ? ... logic.
- Easier to maintain and extend
- App.js looks so much cleaner :)