### PR TITLE
Remove axios

### DIFF
--- a/e2e/utils/firebaseAPI.js
+++ b/e2e/utils/firebaseAPI.js
@@ -1,42 +1,59 @@
-const axios = require('axios');
 const { google } = require('googleapis');
 
-const instance = axios.create({
-  baseURL: process.env.REACT_APP_DB,
-});
+const baseUrl = process.env.REACT_APP_DB;
+const userId = process.env.E2E_TEST_UID;
 
 const scopes = [
   'https://www.googleapis.com/auth/userinfo.email',
   'https://www.googleapis.com/auth/firebase.database',
 ];
 
-const userId = process.env.E2E_TEST_UID;
-
 const promisify = f => (...args) =>
-  new Promise ((pass, fail) =>
-    f (...args, (err, result) => err ? fail(err) : pass(result))
+  new Promise((resolve, reject) =>
+    f(...args, (err, result) => err ? reject(err) : resolve(result))
   );
 
 const _getGoogleApiToken = async () => {
-  const jwtClient = new google.auth.JWT(process.env.FIREBASE_SC_CLIENT_EMAIL, null, process.env.FIREBASE_SC_PRIVATE_KEY.replace(/\\n/gm, '\n'), scopes);
-  return promisify(callback => jwtClient.authorize(callback))();
+  const jwtClient = new google.auth.JWT(
+    process.env.FIREBASE_SC_CLIENT_EMAIL,
+    null,
+    process.env.FIREBASE_SC_PRIVATE_KEY.replace(/\\n/gm, '\n'),
+    scopes
+  );
+  return promisify(cb => jwtClient.authorize(cb))();
 };
 
 const deleteGearItem = async (id) => {
   const { access_token } = await _getGoogleApiToken();
-  return instance.delete(`/users/${userId}/gear/${id}.json`, {  headers: { Authorization: `Bearer ${access_token}` } })
-    .then(res => null)
-    .catch(err => { throw new Error(`Could not delete id ${id} from DB`); });
+  const res = await fetch(`${baseUrl}/users/${userId}/gear/${id}.json`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Could not delete id ${id} from DB`);
+  }
 };
 
 const addGearItem = async (gearItem) => {
   const { access_token } = await _getGoogleApiToken();
-  return instance.post(`/users/${userId}/gear.json`, gearItem, {  headers: { Authorization: `Bearer ${access_token}` } })
-    .then(res => res.data.name)
-    .catch(err => {
-      console.log(err);
-      throw new Error(`Could not add gearItem: ${JSON.stringify(gearItem)}`);
-    });
+  const res = await fetch(`${baseUrl}/users/${userId}/gear.json`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(gearItem),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Could not add gearItem: ${JSON.stringify(gearItem)}\n${errText}`);
+  }
+
+  const data = await res.json();
+  return data.name;
 };
 
 module.exports = { deleteGearItem, addGearItem };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.4",
         "dotenv": "^16.0.0",
         "firebase": "^9.6.9",
         "googleapis": "^99.0.0",
@@ -6564,14 +6563,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -11467,6 +11458,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -29031,14 +29023,6 @@
       "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -32649,7 +32633,8 @@
     "follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.21.4",
     "dotenv": "^16.0.0",
     "firebase": "^9.6.9",
     "googleapis": "^99.0.0",


### PR DESCRIPTION
Since the app is using node 20, we do not need the axios package and can instead rely on built-in `fetch`.

This also resolves a vulnerability we had for the axios version that was used.